### PR TITLE
fix: add cross series reducer to monitoring

### DIFF
--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -47,8 +47,9 @@ resource "google_monitoring_alert_policy" "health_check_policy" {
       threshold_value = 1
 
       aggregations {
-        alignment_period   = "21600s" # 6 hours
-        per_series_aligner = "ALIGN_SUM"
+        alignment_period     = "21600s" # 6 hours
+        per_series_aligner   = "ALIGN_SUM"
+        cross_series_reducer = "REDUCE_SUM"
       }
 
       trigger {


### PR DESCRIPTION
Whenever a new deployment is made, the old time series falls to 0 after a while (since the cloud function is no longer active), causing a false alert because one time series is violating the trigger condition, even though at the same time other is not. Instead, we aggregate all of them to also take into account the new logs coming in from the newly deployed function.