### PR TITLE
fix: remove unsupported incident.url variable from alert documentation

### DIFF
--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -99,10 +99,10 @@ resource "google_monitoring_alert_policy" "error_logs_policy" {
     content   = <<-EOT
       ## Error detected in Governance Watchdog Cloud Function
 
-      **View incident with logs:** $${incident.url}
-      _(Click "View Logs" in the incident page to see logs around the error time)_
+      **View logs around this incident:**
+      https://console.cloud.google.com/logs/query;query=severity%3E%3DERROR%20AND%20resource.labels.service_name%3D%22${google_cloudfunctions2_function.watchdog_notifications.name}%22;timeRange=$${incident.started_at}%2F$${incident.started_at}PT1H
 
-      Or view all recent errors: https://console.cloud.google.com/logs/query;query=severity%3E%3DERROR%20AND%20resource.labels.service_name%3D%22${google_cloudfunctions2_function.watchdog_notifications.name}%22
+      _(Link shows 1 hour of logs starting from when the alert fired)_
     EOT
     mime_type = "text/markdown"
   }


### PR DESCRIPTION
## Problem

Alert notifications were showing:
```
Unrecognized variable: incident.url
```

GCP Cloud Monitoring dropped support for `${incident.url}` in alert policy documentation templates.

## Fix

Replace the broken variable with a direct link to the Cloud Logging query for recent errors.